### PR TITLE
Release main/Smdn.Net.EchonetLite.Primitives-2.0.1

### DIFF
--- a/doc/api-list/Smdn.Net.EchonetLite.Primitives/Smdn.Net.EchonetLite.Primitives-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.Primitives/Smdn.Net.EchonetLite.Primitives-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.Primitives.dll (Smdn.Net.EchonetLite.Primitives-2.0.0)
+// Smdn.Net.EchonetLite.Primitives.dll (Smdn.Net.EchonetLite.Primitives-2.0.1)
 //   Name: Smdn.Net.EchonetLite.Primitives
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+e711220aebaba7dfe17051eed5e6dd8890ffd4d1
+//   AssemblyVersion: 2.0.1.0
+//   InformationalVersion: 2.0.1+a1a02047fb738e30ac5001d6149f8cc18eef4ee6
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:

--- a/doc/api-list/Smdn.Net.EchonetLite.Primitives/Smdn.Net.EchonetLite.Primitives-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.Primitives/Smdn.Net.EchonetLite.Primitives-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.Primitives.dll (Smdn.Net.EchonetLite.Primitives-2.0.0)
+// Smdn.Net.EchonetLite.Primitives.dll (Smdn.Net.EchonetLite.Primitives-2.0.1)
 //   Name: Smdn.Net.EchonetLite.Primitives
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+e711220aebaba7dfe17051eed5e6dd8890ffd4d1
+//   AssemblyVersion: 2.0.1.0
+//   InformationalVersion: 2.0.1+a1a02047fb738e30ac5001d6149f8cc18eef4ee6
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #7](https://github.com/smdn/Smdn.Net.EchonetLite/actions/runs/15651518086).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.EchonetLite.Primitives-2.0.1`
- package_prevver_ref: `releases/Smdn.Net.EchonetLite.Primitives-2.0.0`
- package_prevver_tag: `releases/Smdn.Net.EchonetLite.Primitives-2.0.0`
- package_id: `Smdn.Net.EchonetLite.Primitives`
- package_id_with_version: `Smdn.Net.EchonetLite.Primitives-2.0.1`
- package_version: `2.0.1`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.EchonetLite.Primitives-2.0.1-1749900154`
- release_tag: `releases/Smdn.Net.EchonetLite.Primitives-2.0.1`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/830d4e7073db2dfe27e49c4ace5c08e5`](https://gist.github.com/smdn/830d4e7073db2dfe27e49c4ace5c08e5)
- artifact_name_nupkg: `Smdn.Net.EchonetLite.Primitives.2.0.1.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.EchonetLite.Primitives.latest.nuspec
+++ Smdn.Net.EchonetLite.Primitives.2.0.1.nuspec
@@ -1,27 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.EchonetLite.Primitives</id>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <title>Smdn.Net.EchonetLite.Primitives</title>
     <authors>HiroyukiSakoh,smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.EchonetLite.Primitives.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.EchonetLite</projectUrl>
-    <description>Provides common types and abstractions for `Smdn.Net.EchonetLite.*`. Also provides the APIs based on the specifications described in the "ECHONET Lite SPECIFICATION II ECHONET Lite Communication Middleware Specifications". Including APIs such as `IEchonetLiteHandler`, which is the interface for implementing the communication endpoint to the "Lower Communication Layers".  `Smdn.Net.EchonetLite.*`???????????????????????? ???ECHONET Lite SPECIFICATION ?2? ECHONET Lite ???????????????????????????????????????????????????????`IEchonetLiteHandler`???API???????</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite.Primitives-2.0.0</releaseNotes>
-    <copyright>Copyright � 2018 HiroyukiSakoh, Copyright � 2023 smdn.</copyright>
+    <description>Provides common types and abstractions for `Smdn.Net.EchonetLite.*`. Also provides the APIs based on the specifications described in the "ECHONET Lite SPECIFICATION II ECHONET Lite Communication Middleware Specifications". Including APIs such as `IEchonetLiteHandler`, which is the interface for implementing the communication endpoint to the "Lower Communication Layers".  `Smdn.Net.EchonetLite.*`で共通して使用される型と抽象化機能を提供します。 また「ECHONET Lite SPECIFICATION 第２部 ECHONET Lite 通信ミドルウェア仕様」に記載されている「下位通信層」との通信エンドポイントを実装するための抽象インターフェース`IEchonetLiteHandler`などのAPIも提供します。</description>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite.Primitives-2.0.1</releaseNotes>
+    <copyright>Copyright © 2018 HiroyukiSakoh, Copyright © 2023 smdn.</copyright>
     <tags>smdn.jp abstraction transport connection ECHONET ECHONET-Lite</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" branch="main" commit="e711220aebaba7dfe17051eed5e6dd8890ffd4d1" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" commit="a1a02047fb738e30ac5001d6149f8cc18eef4ee6" />
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.Primitives/bin/Release/net8.0/Smdn.Net.EchonetLite.Primitives.dll" target="lib/net8.0/Smdn.Net.EchonetLite.Primitives.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.Primitives/bin/Release/net8.0/Smdn.Net.EchonetLite.Primitives.xml" target="lib/net8.0/Smdn.Net.EchonetLite.Primitives.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.Primitives/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.Primitives.dll" target="lib/netstandard2.1/Smdn.Net.EchonetLite.Primitives.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.Primitives/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.Primitives.xml" target="lib/netstandard2.1/Smdn.Net.EchonetLite.Primitives.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/.nuget/packages/smdn.msbuild.projectassets.common/1.4.1/project/images/package-icon.png" target="Smdn.Net.EchonetLite.Primitives.png" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.Primitives/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

