### PR TITLE
Release main/Smdn.Net.EchonetLite-2.1.0

### DIFF
--- a/doc/api-list/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.dll (Smdn.Net.EchonetLite-2.0.0)
+// Smdn.Net.EchonetLite.dll (Smdn.Net.EchonetLite-2.1.0)
 //   Name: Smdn.Net.EchonetLite
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+2bb1851c89ba40ded2eeae51a98f8f88d864931f
+//   AssemblyVersion: 2.1.0.0
+//   InformationalVersion: 2.1.0+a1a02047fb738e30ac5001d6149f8cc18eef4ee6
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -51,8 +51,13 @@ namespace Smdn.Net.EchonetLite {
     IAsyncDisposable,
     IDisposable
   {
-    public static readonly ResiliencePropertyKey<ESV> ResiliencePropertyKeyForRequestServiceCode; // = "ResiliencePropertyKeyForRequestServiceCode"
-    public static readonly ResiliencePropertyKey<ESV> ResiliencePropertyKeyForResponseServiceCode; // = "ResiliencePropertyKeyForResponseServiceCode"
+    public static readonly ResiliencePropertyKey<ILogger?> ResiliencePropertyKeyForLogger; // = "EchonetClient.ResiliencePropertyKeyForLogger"
+    public static readonly ResiliencePropertyKey<ESV> ResiliencePropertyKeyForRequestServiceCode; // = "EchonetClient.ResiliencePropertyKeyForRequestServiceCode"
+    public static readonly ResiliencePropertyKey<ESV> ResiliencePropertyKeyForResponseServiceCode; // = "EchonetClient.ResiliencePropertyKeyForResponseServiceCode"
+
+    public static ILogger? GetLoggerForResiliencePipeline(ResilienceContext resilienceContext) {}
+    public static bool TryGetRequestServiceCodeForResiliencePipeline(ResilienceContext resilienceContext, out ESV serviceCode) {}
+    public static bool TryGetResponseServiceCodeForResiliencePipeline(ResilienceContext resilienceContext, out ESV serviceCode) {}
 
     public event EventHandler<EchonetNodeEventArgs>? InstanceListUpdated;
     public event EventHandler<EchonetNodeEventArgs>? InstanceListUpdating;

--- a/doc/api-list/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.dll (Smdn.Net.EchonetLite-2.0.0)
+// Smdn.Net.EchonetLite.dll (Smdn.Net.EchonetLite-2.1.0)
 //   Name: Smdn.Net.EchonetLite
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+2bb1851c89ba40ded2eeae51a98f8f88d864931f
+//   AssemblyVersion: 2.1.0.0
+//   InformationalVersion: 2.1.0+a1a02047fb738e30ac5001d6149f8cc18eef4ee6
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -42,8 +42,13 @@ namespace Smdn.Net.EchonetLite {
     IAsyncDisposable,
     IDisposable
   {
-    public static readonly ResiliencePropertyKey<ESV> ResiliencePropertyKeyForRequestServiceCode; // = "ResiliencePropertyKeyForRequestServiceCode"
-    public static readonly ResiliencePropertyKey<ESV> ResiliencePropertyKeyForResponseServiceCode; // = "ResiliencePropertyKeyForResponseServiceCode"
+    public static readonly ResiliencePropertyKey<ILogger?> ResiliencePropertyKeyForLogger; // = "EchonetClient.ResiliencePropertyKeyForLogger"
+    public static readonly ResiliencePropertyKey<ESV> ResiliencePropertyKeyForRequestServiceCode; // = "EchonetClient.ResiliencePropertyKeyForRequestServiceCode"
+    public static readonly ResiliencePropertyKey<ESV> ResiliencePropertyKeyForResponseServiceCode; // = "EchonetClient.ResiliencePropertyKeyForResponseServiceCode"
+
+    public static ILogger? GetLoggerForResiliencePipeline(ResilienceContext resilienceContext) {}
+    public static bool TryGetRequestServiceCodeForResiliencePipeline(ResilienceContext resilienceContext, out ESV serviceCode) {}
+    public static bool TryGetResponseServiceCodeForResiliencePipeline(ResilienceContext resilienceContext, out ESV serviceCode) {}
 
     public event EventHandler<EchonetNodeEventArgs>? InstanceListUpdated;
     public event EventHandler<EchonetNodeEventArgs>? InstanceListUpdating;


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #8](https://github.com/smdn/Smdn.Net.EchonetLite/actions/runs/15651532076).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.EchonetLite-2.1.0`
- package_prevver_ref: `releases/Smdn.Net.EchonetLite-2.0.0`
- package_prevver_tag: `releases/Smdn.Net.EchonetLite-2.0.0`
- package_id: `Smdn.Net.EchonetLite`
- package_id_with_version: `Smdn.Net.EchonetLite-2.1.0`
- package_version: `2.1.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.EchonetLite-2.1.0-1749900273`
- release_tag: `releases/Smdn.Net.EchonetLite-2.1.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/6d9dd28524edffa77e16498e54a8b2f3`](https://gist.github.com/smdn/6d9dd28524edffa77e16498e54a8b2f3)
- artifact_name_nupkg: `Smdn.Net.EchonetLite.2.1.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.EchonetLite.latest.nuspec
+++ Smdn.Net.EchonetLite.2.1.0.nuspec
@@ -1,31 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.EchonetLite</id>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <title>Smdn.Net.EchonetLite</title>
     <authors>HiroyukiSakoh,smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.EchonetLite.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.EchonetLite</projectUrl>
-    <description>Provides the implementation based on the specifications described in the "ECHONET Lite SPECIFICATION II ECHONET Lite Communication Middleware Specifications". Including APIs such as `EchonetClient`, which is an implementation corresponding to the "Communication Middleware" in the specification.  ?ECHONET Lite SPECIFICATION ?2? ECHONET Lite ??????????????????????????????????????????????????????????`EchonetClient`???API???????</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite-2.0.0</releaseNotes>
-    <copyright>Copyright � 2018 HiroyukiSakoh, Copyright � 2023 smdn.</copyright>
+    <description>Provides the implementation based on the specifications described in the "ECHONET Lite SPECIFICATION II ECHONET Lite Communication Middleware Specifications". Including APIs such as `EchonetClient`, which is an implementation corresponding to the "Communication Middleware" in the specification.  「ECHONET Lite SPECIFICATION 第２部 ECHONET Lite 通信ミドルウェア仕様」に記載されている仕様に基づく実装を提供します。　同仕様書における「通信ミドルウェア」に相当する`EchonetClient`などのAPIを提供します。</description>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite-2.1.0</releaseNotes>
+    <copyright>Copyright © 2018 HiroyukiSakoh, Copyright © 2023 smdn.</copyright>
     <tags>smdn.jp ECHONET ECHONET-Lite</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" branch="main" commit="2bb1851c89ba40ded2eeae51a98f8f88d864931f" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" commit="a1a02047fb738e30ac5001d6149f8cc18eef4ee6" />
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Polly.Core" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Net.EchonetLite.Primitives" version="2.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Polly.Core" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Net.EchonetLite.Primitives" version="2.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite/bin/Release/net8.0/Smdn.Net.EchonetLite.dll" target="lib/net8.0/Smdn.Net.EchonetLite.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite/bin/Release/net8.0/Smdn.Net.EchonetLite.xml" target="lib/net8.0/Smdn.Net.EchonetLite.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.dll" target="lib/netstandard2.1/Smdn.Net.EchonetLite.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.xml" target="lib/netstandard2.1/Smdn.Net.EchonetLite.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/.nuget/packages/smdn.msbuild.projectassets.common/1.4.1/project/images/package-icon.png" target="Smdn.Net.EchonetLite.png" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

