### PR TITLE
Release main/Smdn.Net.EchonetLite.RouteB.Primitives-2.1.0

### DIFF
--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.Primitives/Smdn.Net.EchonetLite.RouteB.Primitives-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.Primitives/Smdn.Net.EchonetLite.RouteB.Primitives-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.RouteB.Primitives.dll (Smdn.Net.EchonetLite.RouteB.Primitives-2.0.0)
+// Smdn.Net.EchonetLite.RouteB.Primitives.dll (Smdn.Net.EchonetLite.RouteB.Primitives-2.1.0)
 //   Name: Smdn.Net.EchonetLite.RouteB.Primitives
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+7829b96052cff6b82bd3e68fb0ced5454037c338
+//   AssemblyVersion: 2.1.0.0
+//   InformationalVersion: 2.1.0+8350a1992a3cc375c86febf128c7a1ab32401211
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -44,7 +44,20 @@ namespace Smdn.Net.EchonetLite.RouteB.Credentials {
   }
 }
 
+namespace Smdn.Net.EchonetLite.RouteB.DependencyInjection {
+  public interface IRouteBServiceBuilder<TServiceKey> {
+    Func<TServiceKey, string?>? OptionsNameSelector { get; }
+    TServiceKey ServiceKey { get; }
+    IServiceCollection Services { get; }
+  }
+
+  public static class IRouteBServiceBuilderExtensions {
+    public static string? GetOptionsName<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder) {}
+  }
+}
+
 namespace Smdn.Net.EchonetLite.RouteB.Transport {
+  [Obsolete("Use IRouteBServiceBuilder instead.")]
   public interface IRouteBEchonetLiteHandlerBuilder {
     IServiceCollection Services { get; }
   }

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.Primitives/Smdn.Net.EchonetLite.RouteB.Primitives-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.Primitives/Smdn.Net.EchonetLite.RouteB.Primitives-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.RouteB.Primitives.dll (Smdn.Net.EchonetLite.RouteB.Primitives-2.0.0)
+// Smdn.Net.EchonetLite.RouteB.Primitives.dll (Smdn.Net.EchonetLite.RouteB.Primitives-2.1.0)
 //   Name: Smdn.Net.EchonetLite.RouteB.Primitives
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+7829b96052cff6b82bd3e68fb0ced5454037c338
+//   AssemblyVersion: 2.1.0.0
+//   InformationalVersion: 2.1.0+8350a1992a3cc375c86febf128c7a1ab32401211
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -41,7 +41,20 @@ namespace Smdn.Net.EchonetLite.RouteB.Credentials {
   }
 }
 
+namespace Smdn.Net.EchonetLite.RouteB.DependencyInjection {
+  public interface IRouteBServiceBuilder<TServiceKey> {
+    Func<TServiceKey, string?>? OptionsNameSelector { get; }
+    TServiceKey ServiceKey { get; }
+    IServiceCollection Services { get; }
+  }
+
+  public static class IRouteBServiceBuilderExtensions {
+    public static string? GetOptionsName<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder) {}
+  }
+}
+
 namespace Smdn.Net.EchonetLite.RouteB.Transport {
+  [Obsolete("Use IRouteBServiceBuilder instead.")]
   public interface IRouteBEchonetLiteHandlerBuilder {
     IServiceCollection Services { get; }
   }


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #9](https://github.com/smdn/Smdn.Net.EchonetLite/actions/runs/15651589136).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.EchonetLite.RouteB.Primitives-2.1.0`
- package_prevver_ref: `releases/Smdn.Net.EchonetLite.RouteB.Primitives-2.0.0`
- package_prevver_tag: `releases/Smdn.Net.EchonetLite.RouteB.Primitives-2.0.0`
- package_id: `Smdn.Net.EchonetLite.RouteB.Primitives`
- package_id_with_version: `Smdn.Net.EchonetLite.RouteB.Primitives-2.1.0`
- package_version: `2.1.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.EchonetLite.RouteB.Primitives-2.1.0-1749900712`
- release_tag: `releases/Smdn.Net.EchonetLite.RouteB.Primitives-2.1.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/49973b7f57656da832ec320d9ce0a5e0`](https://gist.github.com/smdn/49973b7f57656da832ec320d9ce0a5e0)
- artifact_name_nupkg: `Smdn.Net.EchonetLite.RouteB.Primitives.2.1.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.EchonetLite.RouteB.Primitives.latest.nuspec
+++ Smdn.Net.EchonetLite.RouteB.Primitives.2.1.0.nuspec
@@ -1,29 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.EchonetLite.RouteB.Primitives</id>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <title>Smdn.Net.EchonetLite.RouteB.Primitives</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.EchonetLite.RouteB.Primitives.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.EchonetLite</projectUrl>
-    <description>Provides common types and abstractions for `Smdn.Net.EchonetLite.RouteB.*`.  Provides a transport layer abstraction class `RouteBEchonetLiteHandler` to handle ECHONET Lite communication via the **route-B**, the communication path for communicating information with smart electricity meters. Also provides an abstract interface `IRouteBCredential` to handle credentials used in B-route communication path.  `Smdn.Net.EchonetLite.RouteB.*`????????????????????????  ??????????????????????B????????ECHONET Lite????????????????????????`RouteBEchonetLiteHandler`??????? ????????????????????????????????`IRouteBCredential`???????</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite.RouteB.Primitives-2.0.0</releaseNotes>
-    <copyright>Copyright � 2024 smdn</copyright>
+    <description>Provides common types and abstractions for `Smdn.Net.EchonetLite.RouteB.*`.  Provides a transport layer abstraction class `RouteBEchonetLiteHandler` to handle ECHONET Lite communication via the **route-B**, the communication path for communicating information with smart electricity meters. Also provides an abstract interface `IRouteBCredential` to handle credentials used in B-route communication path.  `Smdn.Net.EchonetLite.RouteB.*`で共通して使用される型と抽象化機能を提供します。  スマート電力量メータとの情報伝達手段である「Bルート」を介してECHONET Lite規格の通信を扱うためのトランスポート層抽象クラス`RouteBEchonetLiteHandler`を提供します。 また、その際に使用される認証情報を扱うための抽象インターフェイス`IRouteBCredential`を提供します。</description>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite.RouteB.Primitives-2.1.0</releaseNotes>
+    <copyright>Copyright © 2024 smdn</copyright>
     <tags>smdn.jp abstraction transport Route-B B-Route smart-meter smart-energy-meter ECHONET ECHONET-Lite</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" branch="main" commit="7829b96052cff6b82bd3e68fb0ced5454037c338" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" commit="8350a1992a3cc375c86febf128c7a1ab32401211" />
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Net.EchonetLite.Primitives" version="2.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Net.EchonetLite.Primitives" version="2.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.Primitives/bin/Release/net8.0/Smdn.Net.EchonetLite.RouteB.Primitives.dll" target="lib/net8.0/Smdn.Net.EchonetLite.RouteB.Primitives.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.Primitives/bin/Release/net8.0/Smdn.Net.EchonetLite.RouteB.Primitives.xml" target="lib/net8.0/Smdn.Net.EchonetLite.RouteB.Primitives.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.Primitives/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.RouteB.Primitives.dll" target="lib/netstandard2.1/Smdn.Net.EchonetLite.RouteB.Primitives.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.Primitives/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.RouteB.Primitives.xml" target="lib/netstandard2.1/Smdn.Net.EchonetLite.RouteB.Primitives.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/.nuget/packages/smdn.msbuild.projectassets.common/1.4.1/project/images/package-icon.png" target="Smdn.Net.EchonetLite.RouteB.Primitives.png" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.Primitives/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

