### PR TITLE
Release main/Smdn.Net.EchonetLite.RouteB-2.1.0

### DIFF
--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB-net8.0.apilist.cs
@@ -1,16 +1,16 @@
-// Smdn.Net.EchonetLite.RouteB.dll (Smdn.Net.EchonetLite.RouteB-2.0.0)
+// Smdn.Net.EchonetLite.RouteB.dll (Smdn.Net.EchonetLite.RouteB-2.1.0)
 //   Name: Smdn.Net.EchonetLite.RouteB
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+3138f40758ea06ba8f2c2eee70c4237b7f1411d1
+//   AssemblyVersion: 2.1.0.0
+//   InformationalVersion: 2.1.0+befaca421b43357fbc3b9cbd7d5824a66044d7c6
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
-//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Polly.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc
-//     Smdn.Net.EchonetLite, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite, Version=2.1.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.Primitives, Version=2.0.0.0, Culture=neutral
-//     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.1.0.0, Culture=neutral
 //     System.Collections, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ComponentModel, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ComponentModel.Primitives, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
@@ -33,6 +33,7 @@ using Smdn.Net.EchonetLite;
 using Smdn.Net.EchonetLite.ObjectModel;
 using Smdn.Net.EchonetLite.RouteB;
 using Smdn.Net.EchonetLite.RouteB.Credentials;
+using Smdn.Net.EchonetLite.RouteB.DependencyInjection;
 using Smdn.Net.EchonetLite.RouteB.Transport;
 
 namespace Smdn.Net.EchonetLite.RouteB {
@@ -143,13 +144,30 @@ namespace Smdn.Net.EchonetLite.RouteB {
 
 namespace Smdn.Net.EchonetLite.RouteB.Credentials {
   public static class RouteBCredentialServiceCollectionExtensions {
+    public static IServiceCollection AddRouteBCredential(this IServiceCollection services, object? serviceKey, string id, string password) {}
     public static IServiceCollection AddRouteBCredential(this IServiceCollection services, string id, string password) {}
+    public static IServiceCollection AddRouteBCredentialFromEnvironmentVariable(this IServiceCollection services, object? serviceKey, string envVarForId, string envVarForPassword) {}
     public static IServiceCollection AddRouteBCredentialFromEnvironmentVariable(this IServiceCollection services, string envVarForId, string envVarForPassword) {}
     public static IServiceCollection AddRouteBCredentialProvider(this IServiceCollection services, IRouteBCredentialProvider credentialProvider) {}
+    public static IServiceCollection AddRouteBCredentialProvider(this IServiceCollection services, object? serviceKey, IRouteBCredentialProvider credentialProvider) {}
+  }
+}
+
+namespace Smdn.Net.EchonetLite.RouteB.DependencyInjection {
+  public static class CredentialProviderRouteBServiceBuilderExtensions {
+    public static IRouteBServiceBuilder<TServiceKey> AddCredential<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, string id, string password) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddCredentialFromEnvironmentVariable<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, string envVarForId, string envVarForPassword) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddCredentialProvider<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, IRouteBCredentialProvider credentialProvider) {}
+  }
+
+  public static class RouteBServiceCollectionExtensions {
+    public static IServiceCollection AddRouteB(this IServiceCollection services, Action<IRouteBServiceBuilder<object?>> configure) {}
+    public static IServiceCollection AddRouteB<TServiceKey>(this IServiceCollection services, TServiceKey serviceKey, Func<TServiceKey, string?>? selectOptionsNameForServiceKey, Action<IRouteBServiceBuilder<TServiceKey>> configure) {}
   }
 }
 
 namespace Smdn.Net.EchonetLite.RouteB.Transport {
+  [Obsolete("Use RouteBServiceCollectionExtensions instead.")]
   public static class RouteBEchonetLiteHandlerBuilderServiceCollectionExtensions {
     public static IServiceCollection AddRouteBHandler(this IServiceCollection services, Action<IRouteBEchonetLiteHandlerBuilder> configure) {}
   }

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB/Smdn.Net.EchonetLite.RouteB-netstandard2.1.apilist.cs
@@ -1,16 +1,16 @@
-// Smdn.Net.EchonetLite.RouteB.dll (Smdn.Net.EchonetLite.RouteB-2.0.0)
+// Smdn.Net.EchonetLite.RouteB.dll (Smdn.Net.EchonetLite.RouteB-2.1.0)
 //   Name: Smdn.Net.EchonetLite.RouteB
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+3138f40758ea06ba8f2c2eee70c4237b7f1411d1
+//   AssemblyVersion: 2.1.0.0
+//   InformationalVersion: 2.1.0+befaca421b43357fbc3b9cbd7d5824a66044d7c6
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
-//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Polly.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc
-//     Smdn.Net.EchonetLite, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite, Version=2.1.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.Primitives, Version=2.0.0.0, Culture=neutral
-//     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.0.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.1.0.0, Culture=neutral
 //     netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 #nullable enable annotations
 
@@ -26,6 +26,7 @@ using Smdn.Net.EchonetLite;
 using Smdn.Net.EchonetLite.ObjectModel;
 using Smdn.Net.EchonetLite.RouteB;
 using Smdn.Net.EchonetLite.RouteB.Credentials;
+using Smdn.Net.EchonetLite.RouteB.DependencyInjection;
 using Smdn.Net.EchonetLite.RouteB.Transport;
 
 namespace Smdn.Net.EchonetLite.RouteB {
@@ -130,13 +131,30 @@ namespace Smdn.Net.EchonetLite.RouteB {
 
 namespace Smdn.Net.EchonetLite.RouteB.Credentials {
   public static class RouteBCredentialServiceCollectionExtensions {
+    public static IServiceCollection AddRouteBCredential(this IServiceCollection services, object? serviceKey, string id, string password) {}
     public static IServiceCollection AddRouteBCredential(this IServiceCollection services, string id, string password) {}
+    public static IServiceCollection AddRouteBCredentialFromEnvironmentVariable(this IServiceCollection services, object? serviceKey, string envVarForId, string envVarForPassword) {}
     public static IServiceCollection AddRouteBCredentialFromEnvironmentVariable(this IServiceCollection services, string envVarForId, string envVarForPassword) {}
     public static IServiceCollection AddRouteBCredentialProvider(this IServiceCollection services, IRouteBCredentialProvider credentialProvider) {}
+    public static IServiceCollection AddRouteBCredentialProvider(this IServiceCollection services, object? serviceKey, IRouteBCredentialProvider credentialProvider) {}
+  }
+}
+
+namespace Smdn.Net.EchonetLite.RouteB.DependencyInjection {
+  public static class CredentialProviderRouteBServiceBuilderExtensions {
+    public static IRouteBServiceBuilder<TServiceKey> AddCredential<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, string id, string password) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddCredentialFromEnvironmentVariable<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, string envVarForId, string envVarForPassword) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddCredentialProvider<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, IRouteBCredentialProvider credentialProvider) {}
+  }
+
+  public static class RouteBServiceCollectionExtensions {
+    public static IServiceCollection AddRouteB(this IServiceCollection services, Action<IRouteBServiceBuilder<object?>> configure) {}
+    public static IServiceCollection AddRouteB<TServiceKey>(this IServiceCollection services, TServiceKey serviceKey, Func<TServiceKey, string?>? selectOptionsNameForServiceKey, Action<IRouteBServiceBuilder<TServiceKey>> configure) {}
   }
 }
 
 namespace Smdn.Net.EchonetLite.RouteB.Transport {
+  [Obsolete("Use RouteBServiceCollectionExtensions instead.")]
   public static class RouteBEchonetLiteHandlerBuilderServiceCollectionExtensions {
     public static IServiceCollection AddRouteBHandler(this IServiceCollection services, Action<IRouteBEchonetLiteHandlerBuilder> configure) {}
   }


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #10](https://github.com/smdn/Smdn.Net.EchonetLite/actions/runs/15651651865).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.EchonetLite.RouteB-2.1.0`
- package_prevver_ref: `releases/Smdn.Net.EchonetLite.RouteB-2.0.0`
- package_prevver_tag: `releases/Smdn.Net.EchonetLite.RouteB-2.0.0`
- package_id: `Smdn.Net.EchonetLite.RouteB`
- package_id_with_version: `Smdn.Net.EchonetLite.RouteB-2.1.0`
- package_version: `2.1.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.EchonetLite.RouteB-2.1.0-1749901196`
- release_tag: `releases/Smdn.Net.EchonetLite.RouteB-2.1.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/5a80a98e9bc8771cdbdc27e0f5480444`](https://gist.github.com/smdn/5a80a98e9bc8771cdbdc27e0f5480444)
- artifact_name_nupkg: `Smdn.Net.EchonetLite.RouteB.2.1.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.EchonetLite.RouteB.latest.nuspec
+++ Smdn.Net.EchonetLite.RouteB.2.1.0.nuspec
@@ -1,31 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.EchonetLite.RouteB</id>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <title>Smdn.Net.EchonetLite.RouteB</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.EchonetLite.RouteB.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.EchonetLite</projectUrl>
-    <description>Provides an application layer implementation for communication via the **route-B**, based on the specifications described in the "Interface Specifications for Application Layer Communication between Smart Electric Energy Meters and Controllers".  Provides APIs such as the `HemsController` class, which implements the "HEMS controller" in the specification, and the `LowVoltageSmartElectricEnergyMeter` class, which implements the "Requirements for low-voltage smart electric energy meter class".  ??????????????HEMS ????????????????????????????????????????????B????????????????????????????????  ?????????HEMS ????????????`HemsController`????????????????????????????`LowVoltageSmartElectricEnergyMeter`??????API???????</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite.RouteB-2.0.0</releaseNotes>
-    <copyright>Copyright � 2024 smdn</copyright>
+    <description>Provides an application layer implementation for communication via the **route-B**, based on the specifications described in the "Interface Specifications for Application Layer Communication between Smart Electric Energy Meters and Controllers".  Provides APIs such as the `HemsController` class, which implements the "HEMS controller" in the specification, and the `LowVoltageSmartElectricEnergyMeter` class, which implements the "Requirements for low-voltage smart electric energy meter class".  「低圧スマート電力量メータ・HEMS コントローラ間アプリケーション通信インタフェース仕様書」に記載されている仕様に基づく、「Bルート」を介した通信を行うアプリケーション層の実装を提供します。  同仕様書における「HEMS コントローラ」に相当する`HemsController`クラス、「低圧スマート電力量メータクラス規定」を実装する`LowVoltageSmartElectricEnergyMeter`クラスなどのAPIを提供します。</description>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite.RouteB-2.1.0</releaseNotes>
+    <copyright>Copyright © 2024 smdn</copyright>
     <tags>smdn.jp Route-B B-Route smart-meter smart-energy-meter HEMS HEMS-controller LVSM ECHONET ECHONET-Lite</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" branch="main" commit="3138f40758ea06ba8f2c2eee70c4237b7f1411d1" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" commit="befaca421b43357fbc3b9cbd7d5824a66044d7c6" />
     <dependencies>
       <group targetFramework="net8.0">
-        <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.Net.EchonetLite" version="2.0.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.Net.EchonetLite.RouteB.Primitives" version="2.0.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.DependencyInjection" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.EchonetLite" version="2.1.0" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.EchonetLite.RouteB.Primitives" version="2.1.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
-        <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.Net.EchonetLite" version="2.0.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.Net.EchonetLite.RouteB.Primitives" version="2.0.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.DependencyInjection" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.EchonetLite" version="2.1.0" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.EchonetLite.RouteB.Primitives" version="2.1.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB/bin/Release/net8.0/Smdn.Net.EchonetLite.RouteB.dll" target="lib/net8.0/Smdn.Net.EchonetLite.RouteB.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB/bin/Release/net8.0/Smdn.Net.EchonetLite.RouteB.xml" target="lib/net8.0/Smdn.Net.EchonetLite.RouteB.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.RouteB.dll" target="lib/netstandard2.1/Smdn.Net.EchonetLite.RouteB.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.RouteB.xml" target="lib/netstandard2.1/Smdn.Net.EchonetLite.RouteB.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/.nuget/packages/smdn.msbuild.projectassets.common/1.4.1/project/images/package-icon.png" target="Smdn.Net.EchonetLite.RouteB.png" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

