### PR TITLE
Release main/Smdn.Net.SmartMeter-2.1.0

### DIFF
--- a/doc/api-list/Smdn.Net.SmartMeter/Smdn.Net.SmartMeter-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.SmartMeter/Smdn.Net.SmartMeter-net8.0.apilist.cs
@@ -1,16 +1,18 @@
-// Smdn.Net.SmartMeter.dll (Smdn.Net.SmartMeter-2.0.0)
+// Smdn.Net.SmartMeter.dll (Smdn.Net.SmartMeter-2.1.0)
 //   Name: Smdn.Net.SmartMeter
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+1702d101b7d7da969b9b6258406b4aea5a1b98b4
+//   AssemblyVersion: 2.1.0.0
+//   InformationalVersion: 2.1.0+01af802c78a13826892462d3e0ae20ee33327eb5
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
-//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Polly.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc
-//     Smdn.Net.EchonetLite, Version=2.0.0.0, Culture=neutral
-//     Smdn.Net.EchonetLite.RouteB, Version=2.0.0.0, Culture=neutral
-//     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.0.0.0, Culture=neutral
+//     Polly.Extensions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc
+//     Smdn.Extensions.Polly.KeyedRegistry, Version=1.2.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite, Version=2.1.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.RouteB, Version=2.1.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.1.0.0, Culture=neutral
 //     System.Collections, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ComponentModel, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ComponentModel.Primitives, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
@@ -26,12 +28,35 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.DependencyInjection;
 using Polly.Registry;
+using Polly.Registry.KeyedRegistry;
 using Smdn.Net.EchonetLite.RouteB;
 using Smdn.Net.EchonetLite.RouteB.Credentials;
 using Smdn.Net.EchonetLite.RouteB.Transport;
 using Smdn.Net.SmartMeter;
+
+namespace Smdn.Net.EchonetLite.RouteB.DependencyInjection {
+  public static class SmartMeterDataAggregatorRouteBServiceBuilderExtensions {
+    public static IRouteBServiceBuilder<TServiceKey> AddResiliencePipelineAggregationDataAcquisition<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddResiliencePipelineDataAggregationTask<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddResiliencePipelineSmartMeterConnection<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddResiliencePipelineSmartMeterReadProperty<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddResiliencePipelineSmartMeterReconnection<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddResiliencePipelineSmartMeterWriteProperty<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddResiliencePipelineUpdatingElectricEnergyBaseline<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddRetryAggregationDataAcquisitionTimeout<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, int maxRetryAttempt, TimeSpan delay, Action<RetryStrategyOptions, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configureRetryOptions = null, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configurePipeline = null) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddRetryDataAggregationTaskException<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, int maxRetryAttempt, TimeSpan delay, Action<PredicateBuilder> configureExceptionPredicates, Action<RetryStrategyOptions, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configureRetryOptions = null, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configurePipeline = null) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddRetrySmartMeterConnectionTimeout<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, int maxRetryAttempt, TimeSpan delay, Action<RetryStrategyOptions, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configureRetryOptions = null, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configurePipeline = null) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddRetrySmartMeterReadPropertyException<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, int maxRetryAttempt, TimeSpan delay, Action<PredicateBuilder> configureExceptionPredicates, Action<RetryStrategyOptions, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configureRetryOptions = null, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configurePipeline = null) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddRetrySmartMeterReconnectionTimeout<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, int maxRetryAttempt, TimeSpan delay, Action<RetryStrategyOptions, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configureRetryOptions = null, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configurePipeline = null) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddRetrySmartMeterWritePropertyException<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, int maxRetryAttempt, TimeSpan delay, Action<PredicateBuilder> configureExceptionPredicates, Action<RetryStrategyOptions, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configureRetryOptions = null, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configurePipeline = null) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddRetryUpdatingElectricEnergyBaselineTimeout<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, int maxRetryAttempt, TimeSpan delay, Action<RetryStrategyOptions, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configureRetryOptions = null, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configurePipeline = null) {}
+  }
+}
 
 namespace Smdn.Net.SmartMeter {
   public sealed class CumulativeElectricEnergyAggregation : PeriodicCumulativeElectricEnergyAggregation {
@@ -107,6 +132,29 @@ namespace Smdn.Net.SmartMeter {
   }
 
   public class SmartMeterDataAggregator : HemsController {
+    public readonly struct ResiliencePipelineKeyPair<TServiceKey> :
+      IEquatable<ResiliencePipelineKeyPair<TServiceKey>>,
+      IResiliencePipelineKeyPair<TServiceKey, string>
+    {
+      [CompilerGenerated]
+      public static bool operator == (SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey> left, SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey> right) {}
+      [CompilerGenerated]
+      public static bool operator != (SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey> left, SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey> right) {}
+
+      public ResiliencePipelineKeyPair(TServiceKey serviceKey, string pipelineKey) {}
+
+      public string PipelineKey { get; }
+      public TServiceKey ServiceKey { get; }
+
+      [CompilerGenerated]
+      public bool Equals(SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey> other) {}
+      [CompilerGenerated]
+      public override bool Equals(object obj) {}
+      [CompilerGenerated]
+      public override int GetHashCode() {}
+      public override string ToString() {}
+    }
+
     public static readonly string ResiliencePipelineKeyForAcquirePropertyValuesForAggregatingData = "SmartMeterDataAggregator.resiliencePipelineAcquirePropertyValuesForAggregatingData";
     public static readonly string ResiliencePipelineKeyForRunAggregationTask = "SmartMeterDataAggregator.resiliencePipelineRunAggregationTask";
     public static readonly string ResiliencePipelineKeyForSmartMeterConnection = "SmartMeterDataAggregator.resiliencePipelineConnectToSmartMeter";
@@ -115,8 +163,12 @@ namespace Smdn.Net.SmartMeter {
     public static readonly string ResiliencePipelineKeyForSmartMeterReconnection = "SmartMeterDataAggregator.resiliencePipelineReconnectToSmartMeter";
     public static readonly string ResiliencePipelineKeyForUpdatePeriodicCumulativeElectricEnergyBaselineValue = "SmartMeterDataAggregator.resiliencePipelineUpdatePeriodicCumulativeElectricEnergyBaselineValue";
 
+    public static SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey> CreateResiliencePipelineKeyPair<TServiceKey>(TServiceKey serviceKey, string pipelineKey) {}
+    public static ILogger? GetLoggerForResiliencePipeline(ResilienceContext resilienceContext) {}
+
     public SmartMeterDataAggregator(IEnumerable<SmartMeterDataAggregation> dataAggregations, IRouteBEchonetLiteHandlerFactory echonetLiteHandlerFactory, IRouteBCredentialProvider routeBCredentialProvider, ResiliencePipelineProvider<string>? resiliencePipelineProvider, ILogger? logger, ILoggerFactory? loggerFactoryForEchonetClient) {}
     public SmartMeterDataAggregator(IEnumerable<SmartMeterDataAggregation> dataAggregations, IServiceProvider serviceProvider) {}
+    public SmartMeterDataAggregator(IEnumerable<SmartMeterDataAggregation> dataAggregations, IServiceProvider serviceProvider, object? routeBServiceKey) {}
 
     public IReadOnlyCollection<SmartMeterDataAggregation> DataAggregations { get; }
     public bool IsRunning { get; }
@@ -126,6 +178,27 @@ namespace Smdn.Net.SmartMeter {
     public ValueTask StartAsync(CancellationToken cancellationToken = default) {}
     public async ValueTask StartAsync(TaskFactory? aggregationTaskFactory, CancellationToken cancellationToken = default) {}
     public async ValueTask StopAsync(CancellationToken cancellationToken) {}
+  }
+
+  public static class SmartMeterDataAggregatorServiceCollectionExtensions {
+    public static IServiceCollection AddResiliencePipelineAggregationDataAcquisition(this IServiceCollection services, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<string>> configure) {}
+    public static IServiceCollection AddResiliencePipelineAggregationDataAcquisition<TServiceKey>(this IServiceCollection services, TServiceKey serviceKey, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IServiceCollection AddResiliencePipelineDataAggregationTask(this IServiceCollection services, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<string>> configure) {}
+    public static IServiceCollection AddResiliencePipelineDataAggregationTask<TServiceKey>(this IServiceCollection services, TServiceKey serviceKey, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IServiceCollection AddResiliencePipelineSmartMeterConnection(this IServiceCollection services, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<string>> configure) {}
+    public static IServiceCollection AddResiliencePipelineSmartMeterConnection<TServiceKey>(this IServiceCollection services, TServiceKey serviceKey, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IServiceCollection AddResiliencePipelineSmartMeterReadProperty(this IServiceCollection services, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<string>> configure) {}
+    public static IServiceCollection AddResiliencePipelineSmartMeterReadProperty<TServiceKey>(this IServiceCollection services, TServiceKey serviceKey, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IServiceCollection AddResiliencePipelineSmartMeterReconnection(this IServiceCollection services, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<string>> configure) {}
+    public static IServiceCollection AddResiliencePipelineSmartMeterReconnection<TServiceKey>(this IServiceCollection services, TServiceKey serviceKey, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IServiceCollection AddResiliencePipelineSmartMeterWriteProperty(this IServiceCollection services, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<string>> configure) {}
+    public static IServiceCollection AddResiliencePipelineSmartMeterWriteProperty<TServiceKey>(this IServiceCollection services, TServiceKey serviceKey, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IServiceCollection AddResiliencePipelineUpdatingElectricEnergyBaseline(this IServiceCollection services, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<string>> configure) {}
+    public static IServiceCollection AddResiliencePipelineUpdatingElectricEnergyBaseline<TServiceKey>(this IServiceCollection services, TServiceKey serviceKey, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+  }
+
+  public static class SmartMeterDataAggregatorServiceProviderExtensions {
+    public static ResiliencePipelineProvider<string>? GetResiliencePipelineProviderForSmartMeterDataAggregator(this IServiceProvider serviceProvider, object? serviceKey) {}
   }
 
   public sealed class WeeklyCumulativeElectricEnergyAggregation : PeriodicCumulativeElectricEnergyAggregation {

--- a/doc/api-list/Smdn.Net.SmartMeter/Smdn.Net.SmartMeter-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.SmartMeter/Smdn.Net.SmartMeter-netstandard2.1.apilist.cs
@@ -1,16 +1,18 @@
-// Smdn.Net.SmartMeter.dll (Smdn.Net.SmartMeter-2.0.0)
+// Smdn.Net.SmartMeter.dll (Smdn.Net.SmartMeter-2.1.0)
 //   Name: Smdn.Net.SmartMeter
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+1702d101b7d7da969b9b6258406b4aea5a1b98b4
+//   AssemblyVersion: 2.1.0.0
+//   InformationalVersion: 2.1.0+01af802c78a13826892462d3e0ae20ee33327eb5
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
-//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Polly.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc
-//     Smdn.Net.EchonetLite, Version=2.0.0.0, Culture=neutral
-//     Smdn.Net.EchonetLite.RouteB, Version=2.0.0.0, Culture=neutral
-//     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.0.0.0, Culture=neutral
+//     Polly.Extensions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc
+//     Smdn.Extensions.Polly.KeyedRegistry, Version=1.2.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite, Version=2.1.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.RouteB, Version=2.1.0.0, Culture=neutral
+//     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.1.0.0, Culture=neutral
 //     netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 #nullable enable annotations
 
@@ -20,12 +22,35 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.DependencyInjection;
 using Polly.Registry;
+using Polly.Registry.KeyedRegistry;
 using Smdn.Net.EchonetLite.RouteB;
 using Smdn.Net.EchonetLite.RouteB.Credentials;
 using Smdn.Net.EchonetLite.RouteB.Transport;
 using Smdn.Net.SmartMeter;
+
+namespace Smdn.Net.EchonetLite.RouteB.DependencyInjection {
+  public static class SmartMeterDataAggregatorRouteBServiceBuilderExtensions {
+    public static IRouteBServiceBuilder<TServiceKey> AddResiliencePipelineAggregationDataAcquisition<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddResiliencePipelineDataAggregationTask<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddResiliencePipelineSmartMeterConnection<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddResiliencePipelineSmartMeterReadProperty<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddResiliencePipelineSmartMeterReconnection<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddResiliencePipelineSmartMeterWriteProperty<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddResiliencePipelineUpdatingElectricEnergyBaseline<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddRetryAggregationDataAcquisitionTimeout<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, int maxRetryAttempt, TimeSpan delay, Action<RetryStrategyOptions, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configureRetryOptions = null, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configurePipeline = null) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddRetryDataAggregationTaskException<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, int maxRetryAttempt, TimeSpan delay, Action<PredicateBuilder> configureExceptionPredicates, Action<RetryStrategyOptions, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configureRetryOptions = null, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configurePipeline = null) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddRetrySmartMeterConnectionTimeout<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, int maxRetryAttempt, TimeSpan delay, Action<RetryStrategyOptions, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configureRetryOptions = null, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configurePipeline = null) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddRetrySmartMeterReadPropertyException<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, int maxRetryAttempt, TimeSpan delay, Action<PredicateBuilder> configureExceptionPredicates, Action<RetryStrategyOptions, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configureRetryOptions = null, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configurePipeline = null) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddRetrySmartMeterReconnectionTimeout<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, int maxRetryAttempt, TimeSpan delay, Action<RetryStrategyOptions, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configureRetryOptions = null, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configurePipeline = null) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddRetrySmartMeterWritePropertyException<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, int maxRetryAttempt, TimeSpan delay, Action<PredicateBuilder> configureExceptionPredicates, Action<RetryStrategyOptions, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configureRetryOptions = null, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configurePipeline = null) {}
+    public static IRouteBServiceBuilder<TServiceKey> AddRetryUpdatingElectricEnergyBaselineTimeout<TServiceKey>(this IRouteBServiceBuilder<TServiceKey> builder, int maxRetryAttempt, TimeSpan delay, Action<RetryStrategyOptions, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configureRetryOptions = null, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>>? configurePipeline = null) {}
+  }
+}
 
 namespace Smdn.Net.SmartMeter {
   public sealed class CumulativeElectricEnergyAggregation : PeriodicCumulativeElectricEnergyAggregation {
@@ -101,6 +126,29 @@ namespace Smdn.Net.SmartMeter {
   }
 
   public class SmartMeterDataAggregator : HemsController {
+    public readonly struct ResiliencePipelineKeyPair<TServiceKey> :
+      IEquatable<ResiliencePipelineKeyPair<TServiceKey>>,
+      IResiliencePipelineKeyPair<TServiceKey, string>
+    {
+      [CompilerGenerated]
+      public static bool operator == (SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey> left, SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey> right) {}
+      [CompilerGenerated]
+      public static bool operator != (SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey> left, SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey> right) {}
+
+      public ResiliencePipelineKeyPair(TServiceKey serviceKey, string pipelineKey) {}
+
+      public string PipelineKey { get; }
+      public TServiceKey ServiceKey { get; }
+
+      [CompilerGenerated]
+      public bool Equals(SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey> other) {}
+      [CompilerGenerated]
+      public override bool Equals(object obj) {}
+      [CompilerGenerated]
+      public override int GetHashCode() {}
+      public override string ToString() {}
+    }
+
     public static readonly string ResiliencePipelineKeyForAcquirePropertyValuesForAggregatingData = "SmartMeterDataAggregator.resiliencePipelineAcquirePropertyValuesForAggregatingData";
     public static readonly string ResiliencePipelineKeyForRunAggregationTask = "SmartMeterDataAggregator.resiliencePipelineRunAggregationTask";
     public static readonly string ResiliencePipelineKeyForSmartMeterConnection = "SmartMeterDataAggregator.resiliencePipelineConnectToSmartMeter";
@@ -109,8 +157,12 @@ namespace Smdn.Net.SmartMeter {
     public static readonly string ResiliencePipelineKeyForSmartMeterReconnection = "SmartMeterDataAggregator.resiliencePipelineReconnectToSmartMeter";
     public static readonly string ResiliencePipelineKeyForUpdatePeriodicCumulativeElectricEnergyBaselineValue = "SmartMeterDataAggregator.resiliencePipelineUpdatePeriodicCumulativeElectricEnergyBaselineValue";
 
+    public static SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey> CreateResiliencePipelineKeyPair<TServiceKey>(TServiceKey serviceKey, string pipelineKey) {}
+    public static ILogger? GetLoggerForResiliencePipeline(ResilienceContext resilienceContext) {}
+
     public SmartMeterDataAggregator(IEnumerable<SmartMeterDataAggregation> dataAggregations, IRouteBEchonetLiteHandlerFactory echonetLiteHandlerFactory, IRouteBCredentialProvider routeBCredentialProvider, ResiliencePipelineProvider<string>? resiliencePipelineProvider, ILogger? logger, ILoggerFactory? loggerFactoryForEchonetClient) {}
     public SmartMeterDataAggregator(IEnumerable<SmartMeterDataAggregation> dataAggregations, IServiceProvider serviceProvider) {}
+    public SmartMeterDataAggregator(IEnumerable<SmartMeterDataAggregation> dataAggregations, IServiceProvider serviceProvider, object? routeBServiceKey) {}
 
     public IReadOnlyCollection<SmartMeterDataAggregation> DataAggregations { get; }
     public bool IsRunning { get; }
@@ -120,6 +172,27 @@ namespace Smdn.Net.SmartMeter {
     public ValueTask StartAsync(CancellationToken cancellationToken = default) {}
     public async ValueTask StartAsync(TaskFactory? aggregationTaskFactory, CancellationToken cancellationToken = default) {}
     public async ValueTask StopAsync(CancellationToken cancellationToken) {}
+  }
+
+  public static class SmartMeterDataAggregatorServiceCollectionExtensions {
+    public static IServiceCollection AddResiliencePipelineAggregationDataAcquisition(this IServiceCollection services, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<string>> configure) {}
+    public static IServiceCollection AddResiliencePipelineAggregationDataAcquisition<TServiceKey>(this IServiceCollection services, TServiceKey serviceKey, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IServiceCollection AddResiliencePipelineDataAggregationTask(this IServiceCollection services, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<string>> configure) {}
+    public static IServiceCollection AddResiliencePipelineDataAggregationTask<TServiceKey>(this IServiceCollection services, TServiceKey serviceKey, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IServiceCollection AddResiliencePipelineSmartMeterConnection(this IServiceCollection services, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<string>> configure) {}
+    public static IServiceCollection AddResiliencePipelineSmartMeterConnection<TServiceKey>(this IServiceCollection services, TServiceKey serviceKey, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IServiceCollection AddResiliencePipelineSmartMeterReadProperty(this IServiceCollection services, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<string>> configure) {}
+    public static IServiceCollection AddResiliencePipelineSmartMeterReadProperty<TServiceKey>(this IServiceCollection services, TServiceKey serviceKey, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IServiceCollection AddResiliencePipelineSmartMeterReconnection(this IServiceCollection services, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<string>> configure) {}
+    public static IServiceCollection AddResiliencePipelineSmartMeterReconnection<TServiceKey>(this IServiceCollection services, TServiceKey serviceKey, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IServiceCollection AddResiliencePipelineSmartMeterWriteProperty(this IServiceCollection services, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<string>> configure) {}
+    public static IServiceCollection AddResiliencePipelineSmartMeterWriteProperty<TServiceKey>(this IServiceCollection services, TServiceKey serviceKey, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+    public static IServiceCollection AddResiliencePipelineUpdatingElectricEnergyBaseline(this IServiceCollection services, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<string>> configure) {}
+    public static IServiceCollection AddResiliencePipelineUpdatingElectricEnergyBaseline<TServiceKey>(this IServiceCollection services, TServiceKey serviceKey, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<SmartMeterDataAggregator.ResiliencePipelineKeyPair<TServiceKey>>> configure) {}
+  }
+
+  public static class SmartMeterDataAggregatorServiceProviderExtensions {
+    public static ResiliencePipelineProvider<string>? GetResiliencePipelineProviderForSmartMeterDataAggregator(this IServiceProvider serviceProvider, object? serviceKey) {}
   }
 
   public sealed class WeeklyCumulativeElectricEnergyAggregation : PeriodicCumulativeElectricEnergyAggregation {


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #11](https://github.com/smdn/Smdn.Net.EchonetLite/actions/runs/15651709721).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.SmartMeter-2.1.0`
- package_prevver_ref: `releases/Smdn.Net.SmartMeter-2.0.0`
- package_prevver_tag: `releases/Smdn.Net.SmartMeter-2.0.0`
- package_id: `Smdn.Net.SmartMeter`
- package_id_with_version: `Smdn.Net.SmartMeter-2.1.0`
- package_version: `2.1.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.SmartMeter-2.1.0-1749901724`
- release_tag: `releases/Smdn.Net.SmartMeter-2.1.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/b48f4122023783533e68817162aa1a60`](https://gist.github.com/smdn/b48f4122023783533e68817162aa1a60)
- artifact_name_nupkg: `Smdn.Net.SmartMeter.2.1.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.


