### PR TITLE
Release main/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.1

### DIFF
--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0)
+// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.1)
 //   Name: Smdn.Net.EchonetLite.RouteB.SkStackIP
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+b8918b93e150de00661851f24d5e87d139805913
+//   AssemblyVersion: 2.0.1.0
+//   InformationalVersion: 2.0.1+d43a3f8ed071ed5e6ac93fdfd72d49d75ba986c5
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -13,7 +13,7 @@
 //     Smdn.Extensions.Polly.KeyedRegistry, Version=1.2.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.Primitives, Version=2.0.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.1.0.0, Culture=neutral
-//     Smdn.Net.SkStackIP, Version=1.2.0.0, Culture=neutral
+//     Smdn.Net.SkStackIP, Version=1.5.2.0, Culture=neutral
 //     System.Collections, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ComponentModel, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Memory, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51

--- a/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.EchonetLite.RouteB.SkStackIP/Smdn.Net.EchonetLite.RouteB.SkStackIP-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0)
+// Smdn.Net.EchonetLite.RouteB.SkStackIP.dll (Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.1)
 //   Name: Smdn.Net.EchonetLite.RouteB.SkStackIP
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+b8918b93e150de00661851f24d5e87d139805913
+//   AssemblyVersion: 2.0.1.0
+//   InformationalVersion: 2.0.1+d43a3f8ed071ed5e6ac93fdfd72d49d75ba986c5
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -13,7 +13,7 @@
 //     Smdn.Extensions.Polly.KeyedRegistry, Version=1.2.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.Primitives, Version=2.0.0.0, Culture=neutral
 //     Smdn.Net.EchonetLite.RouteB.Primitives, Version=2.1.0.0, Culture=neutral
-//     Smdn.Net.SkStackIP, Version=1.2.0.0, Culture=neutral
+//     Smdn.Net.SkStackIP, Version=1.5.2.0, Culture=neutral
 //     netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 #nullable enable annotations
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #15](https://github.com/smdn/Smdn.Net.EchonetLite/actions/runs/15825833387).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.1`
- package_prevver_ref: `releases/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0`
- package_prevver_tag: `releases/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0`
- package_id: `Smdn.Net.EchonetLite.RouteB.SkStackIP`
- package_id_with_version: `Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.1`
- package_version: `2.0.1`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.1-1750685923`
- release_tag: `releases/Smdn.Net.EchonetLite.RouteB.SkStackIP-2.0.1`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/156df797276c612f8192c8af2639430d`](https://gist.github.com/smdn/156df797276c612f8192c8af2639430d)
- artifact_name_nupkg: `Smdn.Net.EchonetLite.RouteB.SkStackIP.2.0.1.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Net.EchonetLite.RouteB.SkStackIP.latest.nuspec
+++ Smdn.Net.EchonetLite.RouteB.SkStackIP.2.0.1.nuspec
@@ -1,37 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Net.EchonetLite.RouteB.SkStackIP</id>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <title>Smdn.Net.EchonetLite.RouteB.SkStackIP</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Net.EchonetLite.RouteB.SkStackIP.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.Net.EchonetLite</projectUrl>
-    <description>Skyley Networks?[SKSTACK IP](https://www.skyley.com/wiki/?SKSTACK+IP+for+HAN)?????? ??????????????????????B????????ECHONET Lite???????????API??????? ECHONET Lite?????????????????????`SkStackUdpRouteBHandler`??????????API???????</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite.RouteB.SkStackIP-2.0.0</releaseNotes>
-    <copyright>Copyright � 2024 smdn</copyright>
+    <description>Skyley Networksの[SKSTACK IP](https://www.skyley.com/wiki/?SKSTACK+IP+for+HAN)を使用して、 スマート電力量メータとの情報伝達手段である「Bルート」を介したECHONET Lite規格の通信を扱うためのAPIを提供します。 ECHONET Lite規格における下位通信層に相当する実装である`SkStackUdpRouteBHandler`クラスをはじめとするAPIを提供します。</description>
+    <releaseNotes>https://github.com/smdn/Smdn.Net.EchonetLite/releases/tag/releases%2FSmdn.Net.EchonetLite.RouteB.SkStackIP-2.0.1</releaseNotes>
+    <copyright>Copyright © 2024 smdn</copyright>
     <tags>smdn.jp SKSTACK SKSTACK-IP Route-B B-Route smart-meter smart-energy-meter ECHONET ECHONET-Lite</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" branch="main" commit="b8918b93e150de00661851f24d5e87d139805913" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Net.EchonetLite" commit="d43a3f8ed071ed5e6ac93fdfd72d49d75ba986c5" />
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Options" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Polly.Extensions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Extensions.Polly.KeyedRegistry" version="1.2.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Net.EchonetLite.RouteB.Primitives" version="2.1.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.Net.SkStackIP" version="[1.2.0, 2.0.0)" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.SkStackIP" version="[1.5.2, 2.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Options" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Polly.Extensions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Extensions.Polly.KeyedRegistry" version="1.2.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Net.EchonetLite.RouteB.Primitives" version="2.1.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.Net.SkStackIP" version="[1.2.0, 2.0.0)" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Net.SkStackIP" version="[1.5.2, 2.0.0)" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.SkStackIP/bin/Release/net8.0/Smdn.Net.EchonetLite.RouteB.SkStackIP.dll" target="lib/net8.0/Smdn.Net.EchonetLite.RouteB.SkStackIP.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.SkStackIP/bin/Release/net8.0/Smdn.Net.EchonetLite.RouteB.SkStackIP.xml" target="lib/net8.0/Smdn.Net.EchonetLite.RouteB.SkStackIP.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.SkStackIP/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.RouteB.SkStackIP.dll" target="lib/netstandard2.1/Smdn.Net.EchonetLite.RouteB.SkStackIP.dll" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.SkStackIP/bin/Release/netstandard2.1/Smdn.Net.EchonetLite.RouteB.SkStackIP.xml" target="lib/netstandard2.1/Smdn.Net.EchonetLite.RouteB.SkStackIP.xml" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/.nuget/packages/smdn.msbuild.projectassets.common/1.4.1/project/images/package-icon.png" target="Smdn.Net.EchonetLite.RouteB.SkStackIP.png" />
+    <file src="/home/runner/work/Smdn.Net.EchonetLite/Smdn.Net.EchonetLite/src/Smdn.Net.EchonetLite.RouteB.SkStackIP/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

