### PR TITLE
Release main/Smdn.Net.SmartMeter.Extensions.Munin-2.1.0

### DIFF
--- a/doc/api-list/Smdn.Net.SmartMeter.Extensions.Munin/Smdn.Net.SmartMeter.Extensions.Munin-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Net.SmartMeter.Extensions.Munin/Smdn.Net.SmartMeter.Extensions.Munin-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.SmartMeter.Extensions.Munin.dll (Smdn.Net.SmartMeter.Extensions.Munin-2.0.0)
+// Smdn.Net.SmartMeter.Extensions.Munin.dll (Smdn.Net.SmartMeter.Extensions.Munin-2.1.0)
 //   Name: Smdn.Net.SmartMeter.Extensions.Munin
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+af25552aabd41ce54db2ed417a0dc9390a5dbadf
+//   AssemblyVersion: 2.1.0.0
+//   InformationalVersion: 2.1.0+d6881059bda1389c20c3dc8eacfd375f4dd752fe
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -89,6 +89,12 @@ namespace Smdn.Net.SmartMeter.MuninNode {
 }
 
 namespace Smdn.Net.SmartMeter.MuninNode.Hosting {
+  public class AggregationHaltedException : InvalidOperationException {
+    public AggregationHaltedException() {}
+    public AggregationHaltedException(string message) {}
+    public AggregationHaltedException(string message, Exception? innerException) {}
+  }
+
   public static class IServiceCollectionExtensions {
     public static IServiceCollection AddHostedSmartMeterMuninNodeService(this IServiceCollection services, Action<IRouteBServiceBuilder<string>> configureRouteBServices, Action<MuninNodeOptions> configureMuninNodeOptions, Action<SmartMeterMuninNodeBuilder> configureSmartMeterMuninNode) {}
     public static IServiceCollection AddHostedSmartMeterMuninNodeService<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TSmartMeterMuninNodeService>(this IServiceCollection services, Action<IRouteBServiceBuilder<string>> configureRouteBServices, Action<MuninNodeOptions> configureMuninNodeOptions, Action<SmartMeterMuninNodeBuilder> configureSmartMeterMuninNode) where TSmartMeterMuninNodeService : SmartMeterMuninNodeService {}
@@ -101,6 +107,7 @@ namespace Smdn.Net.SmartMeter.MuninNode.Hosting {
 
     public override void Dispose() {}
     protected override async Task ExecuteAsync(CancellationToken stoppingToken) {}
+    protected virtual void OnAggregationHalted(Exception exception) {}
     protected bool TryGetAggregationFaultedException([NotNullWhen(true)] out Exception? unhandledAggregationException) {}
   }
 }
@@ -120,6 +127,7 @@ namespace Smdn.Net.SmartMeter.MuninNode.Hosting.Systemd {
     public int? ExitCode { get; }
 
     protected virtual bool DetermineExitCodeForUnhandledException(Exception exception, out int exitCode, [NotNullWhen(true)] out string? logMessage) {}
+    protected override void OnAggregationHalted(Exception exception) {}
     public override async Task StartAsync(CancellationToken cancellationToken) {}
     public override async Task StopAsync(CancellationToken cancellationToken) {}
   }

--- a/doc/api-list/Smdn.Net.SmartMeter.Extensions.Munin/Smdn.Net.SmartMeter.Extensions.Munin-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Net.SmartMeter.Extensions.Munin/Smdn.Net.SmartMeter.Extensions.Munin-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Net.SmartMeter.Extensions.Munin.dll (Smdn.Net.SmartMeter.Extensions.Munin-2.0.0)
+// Smdn.Net.SmartMeter.Extensions.Munin.dll (Smdn.Net.SmartMeter.Extensions.Munin-2.1.0)
 //   Name: Smdn.Net.SmartMeter.Extensions.Munin
-//   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0+af25552aabd41ce54db2ed417a0dc9390a5dbadf
+//   AssemblyVersion: 2.1.0.0
+//   InformationalVersion: 2.1.0+d6881059bda1389c20c3dc8eacfd375f4dd752fe
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -83,6 +83,12 @@ namespace Smdn.Net.SmartMeter.MuninNode {
 }
 
 namespace Smdn.Net.SmartMeter.MuninNode.Hosting {
+  public class AggregationHaltedException : InvalidOperationException {
+    public AggregationHaltedException() {}
+    public AggregationHaltedException(string message) {}
+    public AggregationHaltedException(string message, Exception? innerException) {}
+  }
+
   public static class IServiceCollectionExtensions {
     public static IServiceCollection AddHostedSmartMeterMuninNodeService(this IServiceCollection services, Action<IRouteBServiceBuilder<string>> configureRouteBServices, Action<MuninNodeOptions> configureMuninNodeOptions, Action<SmartMeterMuninNodeBuilder> configureSmartMeterMuninNode) {}
     public static IServiceCollection AddHostedSmartMeterMuninNodeService<TSmartMeterMuninNodeService>(this IServiceCollection services, Action<IRouteBServiceBuilder<string>> configureRouteBServices, Action<MuninNodeOptions> configureMuninNodeOptions, Action<SmartMeterMuninNodeBuilder> configureSmartMeterMuninNode) where TSmartMeterMuninNodeService : SmartMeterMuninNodeService {}
@@ -95,6 +101,7 @@ namespace Smdn.Net.SmartMeter.MuninNode.Hosting {
 
     public override void Dispose() {}
     protected override async Task ExecuteAsync(CancellationToken stoppingToken) {}
+    protected virtual void OnAggregationHalted(Exception exception) {}
     protected bool TryGetAggregationFaultedException([NotNullWhen(true)] out Exception? unhandledAggregationException) {}
   }
 }
@@ -114,6 +121,7 @@ namespace Smdn.Net.SmartMeter.MuninNode.Hosting.Systemd {
     public int? ExitCode { get; }
 
     protected virtual bool DetermineExitCodeForUnhandledException(Exception exception, out int exitCode, [NotNullWhen(true)] out string? logMessage) {}
+    protected override void OnAggregationHalted(Exception exception) {}
     public override async Task StartAsync(CancellationToken cancellationToken) {}
     public override async Task StopAsync(CancellationToken cancellationToken) {}
   }


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #16](https://github.com/smdn/Smdn.Net.EchonetLite/actions/runs/15956328601).

# Release target
- package_target_tag: `new-release/main/Smdn.Net.SmartMeter.Extensions.Munin-2.1.0`
- package_prevver_ref: `releases/Smdn.Net.SmartMeter.Extensions.Munin-2.0.0`
- package_prevver_tag: `releases/Smdn.Net.SmartMeter.Extensions.Munin-2.0.0`
- package_id: `Smdn.Net.SmartMeter.Extensions.Munin`
- package_id_with_version: `Smdn.Net.SmartMeter.Extensions.Munin-2.1.0`
- package_version: `2.1.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Net.SmartMeter.Extensions.Munin-2.1.0-1751208116`
- release_tag: `releases/Smdn.Net.SmartMeter.Extensions.Munin-2.1.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/42aa7aade72dbd371276145ad3fbe31b`](https://gist.github.com/smdn/42aa7aade72dbd371276145ad3fbe31b)
- artifact_name_nupkg: `Smdn.Net.SmartMeter.Extensions.Munin.2.1.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.


